### PR TITLE
support configurable scrape delay and emit completion event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ tests/node_modules/
 tests/list-utilities.bundle.js
 tests/list-utilities.bundle.js.map
 tests/.playwright/
+
+docs/

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ tests/list-utilities.bundle.js.map
 tests/.playwright/
 
 docs/
+
+.worktrees/

--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -220,6 +220,7 @@ export class REXChatGPTSpider extends REXSpider {
 
                                         this.syncing = false
 
+                                        this.dispatchCompletionEvent(crawledCount)
                                         resolve(true) // Error - fall back to DOM scraping...
                                       }
                                     })
@@ -232,6 +233,7 @@ export class REXChatGPTSpider extends REXSpider {
                         } else {
                           this.syncing = false
 
+                          this.dispatchCompletionEvent(0)
                           resolve(true) // Error - fall back to DOM scraping...
                         }
                       })

--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -10,6 +10,33 @@ export class REXChatGPTSpider extends REXSpider {
   syncPeriod:number = 300000
   accessToken:string|null = null
 
+  constructor() {
+    super()
+
+    // Override sleepDelayMs from server config if provided.
+    rexCorePlugin.fetchConfiguration()
+      .then((config) => {
+        const spiderConfig = (config as Record<string, any>)?.spider?.chatgpt // eslint-disable-line @typescript-eslint/no-explicit-any
+        const configuredDelay = spiderConfig?.sleep_delay_ms
+        if (typeof configuredDelay === 'number') {
+          this.sleepDelayMs = configuredDelay
+        }
+      })
+      .catch((err) => console.warn('[rex-spider-chatgpt] Failed to read sleep_delay_ms from config:', err))
+  }
+
+  private dispatchCompletionEvent(crawledCount: number): void {
+    // Delay mirrors the rex-history completion pattern: waits for PDK's
+    // persist debounce to expire so queued events flush before the signal.
+    setTimeout(() => {
+      dispatchEvent({
+        name: 'rex-spider-chatgpt-complete',
+        crawled_count: crawledCount,
+        date: Date.now()
+      })
+    }, 1100)
+  }
+
   fetchUrls(): string[] {
     return ['https://www.perplexity.ai/library']
   }
@@ -79,6 +106,7 @@ export class REXChatGPTSpider extends REXSpider {
 
         if (Date.now() < timestamp + this.syncPeriod) {
           console.log(`[rex-spider-chatgpt] Too soon to sync again. Skipping this round...`)
+          this.dispatchCompletionEvent(0)
           resolve(true)
 
           return
@@ -134,6 +162,8 @@ export class REXChatGPTSpider extends REXSpider {
                         if (response.ok) {
                           const toCrawl = []
 
+                          let crawledCount = 0
+
                           response.json().then((convoList) => {
                             console.log(`[rex-spider-chatgpt] Index content:`)
                             console.log(convoList)
@@ -155,6 +185,7 @@ export class REXChatGPTSpider extends REXSpider {
                               if (toCrawl.length == 0) {
                                 this.syncing = false
 
+                                this.dispatchCompletionEvent(crawledCount)
                                 resolve(false)
                               } else {
                                 self.setTimeout(() => {
@@ -177,6 +208,7 @@ export class REXChatGPTSpider extends REXSpider {
 
                                             if (payload !== null) {
                                               dispatchEvent(payload)
+                                              crawledCount += 1
                                             }
 
                                             fetchConvo()

--- a/src/service-worker.mts
+++ b/src/service-worker.mts
@@ -125,8 +125,15 @@ export class REXChatGPTSpider extends REXSpider {
 
           fetch(homeUrl)
             .then((response: Response) => {
-              if (response.ok) {
-                response.text().then((rawHtml) => {
+              if (!response.ok) {
+                console.log(`[rex-spider-chatgpt] Homepage fetch failed (status ${response.status}).`)
+                this.syncing = false
+                this.dispatchCompletionEvent(0)
+                resolve(true) // Error - fall back to DOM scraping...
+                return
+              }
+
+              response.text().then((rawHtml) => {
                   const lines = rawHtml.match(/[^\r\n]+/g)
 
                   for (const line of lines) {
@@ -147,8 +154,15 @@ export class REXChatGPTSpider extends REXSpider {
                     }
                   }
 
-                  if (this.accessToken !== null) {
-                    console.log(`[rex-spider-chatgpt] USING ACCESS TOKEN: ${this.accessToken}`)
+                  if (this.accessToken === null) {
+                    console.log(`[rex-spider-chatgpt] No access token — user is not logged in.`)
+                    this.syncing = false
+                    this.dispatchCompletionEvent(0)
+                    resolve(true) // Not logged in — fall back to DOM scraping...
+                    return
+                  }
+
+                  console.log(`[rex-spider-chatgpt] USING ACCESS TOKEN: ${this.accessToken}`)
 
                     const indexUrl = 'https://chatgpt.com/backend-api/conversations?offset=0&limit=28&order=updated&is_archived=false&is_starred=false'
 
@@ -237,9 +251,13 @@ export class REXChatGPTSpider extends REXSpider {
                           resolve(true) // Error - fall back to DOM scraping...
                         }
                       })
-                  }
                 })
-              }
+            })
+            .catch((err) => {
+              console.log(`[rex-spider-chatgpt] Unexpected error during sync:`, err)
+              this.syncing = false
+              this.dispatchCompletionEvent(0)
+              resolve(true) // Error - fall back to DOM scraping...
             })
         })
       })


### PR DESCRIPTION
Needed for testing offboarding

  Summary of the work on rex-spider-chatgpt:
                                                                                                                          
  Branch: configurable-delay-and-completion-event (off main, clean tree, no commit yet)                                   
   
  Diff: src/service-worker.mts only, +31/-0 lines, no re-indentation                                                      
                                                            
  Changes:                                                                                                                
  1. Constructor added to REXChatGPTSpider: fetches rex-core config once at module load, overrides this.sleepDelayMs if
  config.spider.chatgpt.sleep_delay_ms is set. Silent fallback to the existing 10000ms default if config absent or missing
   the field.                                                                                                             
  2. dispatchCompletionEvent(crawledCount) helper: emits rex-spider-chatgpt-complete event with { crawled_count, date },  
  after a 1100ms delay to let PDK's persist debounce flush (pattern copied from rex-history).                           
  3. Emit on clean drain: when toCrawl.length == 0, fires the event with total crawled count.                             
  4. Emit on too-soon-to-sync early return: fires with count=0 so offboarding doesn't hang when the user runs offboarding
  within the 5-min sync window.                                                                                           
  5. Does NOT emit on error/fall-back paths (resolve(true)) — those hand off to DOM scraping which isn't yet wired to emit
   its own completion. Worth flagging in the PR.                                                                          
                                                                                                                          
  Verified:                                                 
  - npm run build — no new errors (one pre-existing @bric/rex-types/types unresolved)                                     
  - npm run lint — no new errors (11 pre-existing, same count after change) 